### PR TITLE
Fix some ci errors

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -112,8 +112,8 @@ jobs:
 
     needs:
       - sanity
-      - units
-      - integration
+      # - units
+      # - integration
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,0 +1,124 @@
+---
+# README FIRST
+# 1. Subscribe to https://github.com/ansible-collections/news-for-maintainers
+#    (click the Watch button on the homepage > Custom > Issues)
+#    and keep this matrix up to date in accordance to related announcements.
+#    Timely add new ansible-core versions and consider dropping support
+#    and testing against its EOL versions.
+# 2. If your collection repository is under the ansible-collections org,
+#    please keep in mind that the number of GHA jobs is limited
+#    and shared across all the collections in the org.
+#    So, focusing on good test coverage of your collection,
+#    please avoid testing against unnecessary entities such as
+#    ansible-core EOL versions your collection does not support
+#    or ansible-core versions that are not EOL yet but not supported by the collection.
+# 3. If you don't have unit or integration tests, remove corresponding sections.
+# 4. If your collection depends on other collections ensure they are installed,
+#    add them to the "test-deps" input.
+# 5. For the comprehensive list of the inputs supported by the
+#    ansible-community/ansible-test-gh-action GitHub Action, see
+#    https://github.com/marketplace/actions/ansible-test.
+# 6. If you want to prevent merging PRs that do not pass all tests,
+#    make sure to add the "check" job to your repository branch
+#    protection once this workflow is added.
+#    It is also possible to tweak which jobs are allowed to fail. See
+#    https://github.com/marketplace/actions/alls-green#gotchas for more detail.
+# 7. If you need help please ask in #community:ansible.com on Matrix
+#    or in bridged #ansible-community on the Libera.Chat IRC channel.
+#    See https://docs.ansible.com/ansible/devel/community/communication.html
+#    for details.
+# 8. If your collection is [going to get] included in the Ansible package,
+#    it has to adhere to Python compatibility and CI testing requirements described in
+#    https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_requirements.html.
+
+name: CI
+on:
+  # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run CI once per day (at 06:00 UTC)
+  # This ensures that even if there haven't been commits that we are still
+  # testing against latest version of ansible-test for each ansible-core
+  # version
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
+
+jobs:
+
+###
+# Sanity tests (REQUIRED)
+#
+# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+
+  sanity:
+    name: Sanity (Ⓐ${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible:
+          # It's important that Sanity is tested against all stable-X.Y branches
+          # Testing against `devel` may fail as new tests are added.
+          # An alternative to `devel` is the `milestone` branch with
+          # gets synchronized with `devel` every few weeks and therefore
+          # tends to be a more stable target. Be aware that it is not updated
+          # around creation of a new stable branch, this might cause a problem
+          # that two different versions of ansible-test use the same sanity test
+          # ignore.txt file.
+          # Add new versions announced in
+          # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
+          # consider dropping testing against EOL versions and versions you don't support.
+          - stable-2.16
+          - stable-2.17
+          - stable-2.18
+          - devel
+          # - milestone
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Run sanity tests inside a Docker container.
+      # The docker container has all the pinned dependencies that are
+      # required and all Python versions Ansible supports.
+      - name: Perform sanity testing
+        # See the documentation for the following GitHub action on
+        # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: ${{ matrix.ansible }}
+          testing-type: sanity
+          # OPTIONAL If your sanity tests require code
+          # from other collections, install them like this
+          # test-deps: >-
+          #   ansible.netcommon
+          #   ansible.utils
+          # OPTIONAL If set to true, will test only against changed files,
+          # which should improve CI performance. See limitations on
+          # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
+          pull-request-change-detection: false
+
+  check:  # This job does nothing and is only used for the branch protection
+          # or multi-stage CI jobs, like making sure that all tests pass before
+          # a publishing job is started.
+    if: always()
+
+    needs:
+      - sanity
+      - units
+      - integration
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+/tests/output/
+/changelogs/.plugin-cache.yaml
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/plugins/module_utils/gluware_utils.py
+++ b/plugins/module_utils/gluware_utils.py
@@ -1,7 +1,10 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, Gluware Inc.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import json
 from urllib.parse import urljoin
 
@@ -59,7 +62,7 @@ class GluwareAPIClient:
                 if device.get('name') == name:
                     found = True
                     return device
-            if found == False:
+            if found is False:
                 for device in devices:
                     if device.get('discoveredHostname') == name:
                         found = True

--- a/plugins/modules/glu_audit_config.py
+++ b/plugins/modules/glu_audit_config.py
@@ -2,19 +2,10 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, Gluware Inc.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
-from ansible_collections.gluware_inc.control.plugins.module_utils.gluware_utils import GluwareAPIClient
-import os
-import json
-import re
-import urllib.error as urllib_error
-import http.client as httplib
-import socket
-from ansible.module_utils.urls import Request
-from ansible.module_utils.basic import AnsibleModule
-ANSIBLE_METADATA = {'metadata_version': '1.1.0',
-                    'status': ['stableinterface'],
-                    'supported_by': 'Gluware Inc'}
+from __future__ import annotations
 
 DOCUMENTATION = '''
     module: glu_audit_config
@@ -22,11 +13,10 @@ DOCUMENTATION = '''
     description:
     - For the current Gluware device trigger a audit on the current captured config in Gluware Control.
     - By default this module will use device_id parameter to find the device in Gluware.
-    - This module supports specifying the friendly name of the device if the organization name is specified as well instead of supplying the device_id parameter.  
-    version_added: '2.8'
+    - Module supports specifying the friendly name of the device if the organization name is specified as well instead of supplying the device_id parameter.
     author:
-    - John Anderson
-    - Oleg Gratwick
+    - John Anderson (@gluware-inc)
+    - Oleg Gratwick (@ogratwick)
     options:
         gluware_control:
             description:
@@ -36,41 +26,41 @@ DOCUMENTATION = '''
             suboptions:
                 host:
                     description: Hostname or IP address of the Gluware Control server.
-                    type: string
+                    type: str
                 username:
                     description: Username for authentication with Gluware Control.
-                    type: string
+                    type: str
                 password:
                     description: Password for authentication with Gluware Control.
-                    type: string
+                    type: str
                 trust_https_certs:
                     description: Bypass HTTPS certificate verification.
-                    type: boolean
+                    type: bool
         glu_device_id:
             description:
             - ID of the device within Gluware.
             - The glu_devices inventory plugin automatically supplies this variable.
-            type: string
+            type: str
             required: False
         org_name:
             description:
             - Organization name the device is in within Gluware.
-            type: string
+            type: str
             required: False
         name:
             description:
             - Target device name within Gluware Control.
-            type: string
+            type: str
             required: False
         description:
             description:
             - Description for the instance of this audit execution.
-            type: string
+            type: str
             required: True
         audit_policy:
             description:
             - Audit Policy Name as displayed in Gluware Config Drift & Audit.
-            type: string
+            type: str
             required: True
 '''
 
@@ -87,6 +77,16 @@ EXAMPLES = r'''
 
 
 '''
+
+from ansible_collections.gluware_inc.control.plugins.module_utils.gluware_utils import GluwareAPIClient
+import os
+import json
+import re
+import urllib.error as urllib_error
+import http.client as httplib
+import socket
+from ansible.module_utils.urls import Request
+from ansible.module_utils.basic import AnsibleModule
 
 
 try:
@@ -110,7 +110,7 @@ def run_module():
             options=dict(
                 host=dict(type='str', required=False),
                 username=dict(type='str', required=False),
-                password=dict(type='str', required=False),
+                password=dict(type='str', required=False, no_log=True),
                 trust_any_host_https_certs=dict(
                     type='bool', required=False, default=False)
             )
@@ -192,7 +192,7 @@ def run_module():
         module.fail_json(msg=f"No organization found with name {org_name}")
     org_id = glu_org_id[0].get('id')
     # This api call is for Gluware Control.
-    api_url_1 = urljoin(api_host, '/api/audit/policies?orgId='+org_id)
+    api_url_1 = urljoin(api_host, '/api/audit/policies?orgId=' + org_id)
 
     try:
         response = request_handler.get(api_url_1)
@@ -234,7 +234,6 @@ def run_module():
         "policyId": audit_policy_id,
         "capture": False
     }
-    print(audit_policy_id)
     http_body = json.dumps(api_data)
 
     # Make the actual api call.

--- a/plugins/modules/glu_update_device_attributes.py
+++ b/plugins/modules/glu_update_device_attributes.py
@@ -86,8 +86,8 @@ EXAMPLES = r'''
       gluware_inc.control.glu_update_device_attributes:
         org_name: "gluware_organization"
         name: "device_01"
-        gluware_control: 
-        host: "https://1.1.1.1"
+        gluware_control:
+          host: "https://1.1.1.1"
           username: "ansible_user"
           password: "ansible_password"
           trust_any_host_https_certs: true
@@ -95,11 +95,6 @@ EXAMPLES = r'''
           description: "Updated Device Description"
 
 '''
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2020, Gluware Inc.
-
 
 try:
     from urlparse import urljoin


### PR DESCRIPTION
This shows how to fix most of the issues. That should provide you with a reference for fixing the rest. In particular:

- Fixes inventory/glu_devices.py
- Fixes modules/glu_audit_config.py (so you can copy these fixes to your other modules)
- Adds a GitHub action for "ansible-test sanity" (so you can be confident of your collection)

Please note, I've not validated these changes, so **please review carefully** and do ask if anything doesn't make sense


## Fixing ModuleNotFoundError: No module named 'requests'
Python Imports should be validated, and gracefully handled. 
[Import check](https://github.com/ansible-collections/community.network/blob/main/plugins/module_utils/network/aos/aos.py#L52-L57)
[Graceful error](https://github.com/ansible-collections/community.network/blob/main/plugins/module_utils/network/aos/aos.py#L67-L69)

## Suggestion: common argspec & documentation Fragment for shared docs

I would suggest that you move the common module options into plugins/module_utils/gluware_utils.py and have a corresponding plugins/doc_fragments/glueware.py. 
The easiest way to show this, is looking at the MySQL collection
* Common docs are defined in [docs_fragments](https://github.com/ansible-collections/community.mysql/blob/main/plugins/doc_fragments/mysql.py)
* The corresponding module args are defined in this function [module_utils](https://github.com/ansible-collections/community.mysql/blob/main/plugins/module_utils/mysql.py#L188-L201)
* Each module references the [documentation fragments](https://github.com/ansible-collections/community.mysql/blob/main/plugins/modules/mysql_db.py#L198-L199)
* Each module [loads in the shared argument_spec](https://github.com/ansible-collections/community.mysql/blob/main/plugins/modules/mysql_db.py#L614)

## Suggestion: Use built in functionality for environment variables
To simplify you code and prevent passwords being accidently leaked, I suggest you use the [fallback](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#:~:text=is%20None.-,fallback,-%3A) functionality of the argspec, this will go nicely with the above suggestion of Docs Fragments & common argspec in module_utils

Example argspec
```
username=dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME']))
```


## Useful documentation
[Documenting your module](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html)
[Developing inventory Plugins](https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#developing-inventory-plugins)
[Ansible Module Architecture](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html)